### PR TITLE
Force BarricadeGhosting to false

### DIFF
--- a/lua/d3bot/sv_zs_bot_handler/supervisor.lua
+++ b/lua/d3bot/sv_zs_bot_handler/supervisor.lua
@@ -81,6 +81,7 @@ function D3bot.MaintainBotRoles()
 			randomBot:StripWeapons()
 			--randomBot:KillSilent()
 			randomBot:Kill()
+			randomBot:SetBarricadeGhosting(false)
 			return
 		end
 	end
@@ -97,6 +98,9 @@ function D3bot.MaintainBotRoles()
 					spawnAsTeam = nil
 					if IsValid(bot) then
 						bot:D3bot_InitializeOrReset()
+						if team == TEAM_UNDEAD then
+							bot:SetBarricadeGhosting(false)
+						end
 					end
 				end
 				return


### PR DESCRIPTION
Use SetBarricadeGhosting method on newly spawned bots and bots that are moved from the survivor to the undead team. This should prevent undead bots from ghosting through barricades.

#99
#36